### PR TITLE
Enrich tips table

### DIFF
--- a/lib/notion/blog.ts
+++ b/lib/notion/blog.ts
@@ -2,20 +2,18 @@ import { getTableContents } from "./table";
 import { Post } from "lib/types";
 
 export const getPublishedPosts = async () => {
-  const posts = ((await getTableContents(
-    process.env.BLOG_ID,
-    process.env.NOTION_TOKEN
-  )) as unknown) as Post[];
+  const posts = ((await getTableContents(process.env.BLOG_ID, {
+    notionToken: process.env.NOTION_TOKEN,
+  })) as unknown) as Post[];
   return process.env.NODE_ENV === "development"
     ? posts
     : posts.filter((post) => post.Published);
 };
 
 export const fetchPostMetaFromSlug = async (slug: string) => {
-  const posts = ((await getTableContents(
-    process.env.BLOG_ID,
-    process.env.NOTION_TOKEN
-  )) as unknown) as Post[];
+  const posts = ((await getTableContents(process.env.BLOG_ID, {
+    notionToken: process.env.NOTION_TOKEN,
+  })) as unknown) as Post[];
 
   return posts.find((post) => post.Slug?.split(",").includes(slug));
 };

--- a/lib/notion/table.ts
+++ b/lib/notion/table.ts
@@ -10,9 +10,12 @@ import { getNotionValue } from "./utils";
 
 type Row = { id: string; [key: string]: RowContentType };
 
+interface TableContentOptions {
+  notionToken?: string;
+}
 export const getTableContents = async (
   tableId: string,
-  notionToken?: string
+  { notionToken }: TableContentOptions = {}
 ) => {
   const page = await fetchPageById(tableId, notionToken);
 

--- a/lib/notion/table.ts
+++ b/lib/notion/table.ts
@@ -6,16 +6,17 @@ import {
   RowContentType,
   fetchNotionUsers,
 } from ".";
-import { getNotionValue } from "./utils";
+import { getNotionValue, getNotionVerboseValue } from "./utils";
 
 type Row = { id: string; [key: string]: RowContentType };
 
 interface TableContentOptions {
   notionToken?: string;
+  verbose?: boolean;
 }
 export const getTableContents = async (
   tableId: string,
-  { notionToken }: TableContentOptions = {}
+  { notionToken, verbose = false }: TableContentOptions = {}
 ) => {
   const page = await fetchPageById(tableId, notionToken);
 
@@ -59,7 +60,9 @@ export const getTableContents = async (
       const val = td.value.properties[key];
       if (val) {
         const schema = collectionRows[key];
-        row[schema.name] = getNotionValue(val, schema.type);
+        row[schema.name] = verbose
+          ? (getNotionVerboseValue(val, schema) as any)
+          : getNotionValue(val, schema.type);
         if (schema.type === "person") {
           const users = await fetchNotionUsers(row[schema.name] as string[]);
           row[schema.name] = users;

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -22,10 +22,22 @@ export type ColumnType =
   | "multi_select"
   | "number";
 
-export type ColumnSchemaType = {
+export type MultiSelectSchemaType = {
   name: string;
-  type: ColumnType;
+  type: "multi_select";
+  options: Array<{
+    id: string;
+    color: string;
+    value: string;
+  }>;
 };
+
+export type ColumnSchemaType =
+  | {
+      name: string;
+      type: Exclude<ColumnType, "multi_select">;
+    }
+  | MultiSelectSchemaType;
 
 export interface CollectionType {
   value: {

--- a/pages/api/post/[slug].ts
+++ b/pages/api/post/[slug].ts
@@ -6,10 +6,9 @@ import { Post } from "lib/types";
 export default async function (req: NowRequest, res: NowResponse) {
   const { slug } = req.query;
 
-  const posts = ((await getTableContents(
-    process.env.BLOG_ID,
-    process.env.NOTION_TOKEN
-  )) as unknown) as Post[];
+  const posts = ((await getTableContents(process.env.BLOG_ID, {
+    notionToken: process.env.NOTION_TOKEN,
+  })) as unknown) as Post[];
 
   const id = posts.find((post) => post.Slug.split(",").includes(slug as string))
     ?.id;

--- a/pages/posts/[post].tsx
+++ b/pages/posts/[post].tsx
@@ -10,10 +10,9 @@ import pLocate from "p-locate";
 import { Title } from "lib/components/title";
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const posts = ((await getTableContents(
-    process.env.BLOG_ID,
-    process.env.NOTION_TOKEN
-  )) as unknown) as Post[];
+  const posts = ((await getTableContents(process.env.BLOG_ID, {
+    notionToken: process.env.NOTION_TOKEN,
+  })) as unknown) as Post[];
 
   return {
     paths: posts

--- a/pages/tips.tsx
+++ b/pages/tips.tsx
@@ -75,7 +75,7 @@ export const getStaticProps: GetStaticProps = async () => {
         return tip;
       }),
     },
-    revalidate: 60 * 10, // Revalidate at most every 10 minutes
+    revalidate: 60, // Revalidate at most every minute
   };
 };
 


### PR DESCRIPTION
As a continuation of my improvements on the tips page, I've added the ability to do two new things. 
1. Render links included in notion text
2. Retain the label colors from notion

## Before

<img width="756" alt="image" src="https://user-images.githubusercontent.com/3087225/103314634-a2ab1880-49f1-11eb-8539-77c74c086a44.png">

## After

<img width="768" alt="image" src="https://user-images.githubusercontent.com/3087225/103314660-ae96da80-49f1-11eb-9fb1-99d564e147b1.png">

Links are denoted in bold to stand out a little more. 