### PR TITLE
Update tips to render code

### DIFF
--- a/lib/notion/utils.ts
+++ b/lib/notion/utils.ts
@@ -18,11 +18,16 @@ export const parsePageId = (id: string) => {
 
 const getRichTextContent = (text: DecorationType[]) => {
   return text.reduce((prev, current) => {
-    const link = current[1]?.find((decoration) => decoration[0] === "a")?.[1];
-    if (link) {
-      return prev + `<a href="${link}">${current[0]}</a>`;
+    const decoration = current[1]?.[0]?.[0];
+    switch (decoration) {
+      case "a":
+        const link = current[1][1];
+        return prev + `<a href="${link}">${current[0]}</a>`;
+      case "c":
+        return prev + `<pre>${current[0]}</pre>`;
+      default:
+        return prev + current[0];
     }
-    return prev + current[0];
   }, "");
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@chakra-ui/react": "^1.0.1",
     "@emotion/react": "^11.1.1",
     "@emotion/styled": "^11.0.0",
+    "date-fns": "^2.16.1",
     "feed": "^4.2.1",
     "framer-motion": "^2.9.4",
     "isomorphic-unfetch": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2142,6 +2142,11 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
 debug@4:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"


### PR DESCRIPTION
Does two things:
- Sorts tips in descending order from created date
- Adds newline and code highlighting support for tips

I might update the rendering strategy at some point to use the NotionRenderer instead of manually re-implementing these individual updates